### PR TITLE
substitute RCPP_UNORDERED_MAP with std::unordered_map

### DIFF
--- a/src/get_idf.cpp
+++ b/src/get_idf.cpp
@@ -3,7 +3,7 @@
 
 using namespace Rcpp;
 using namespace std;
-typedef RCPP_UNORDERED_MAP< string, pair<unsigned int,unsigned int > > IDFmap;
+typedef std::unordered_map< string, pair<unsigned int,unsigned int > > IDFmap;
 
 void inner_find(CharacterVector& y,IDFmap& m,unsigned int dis){
   for(CharacterVector::iterator it = y.begin();it!=y.end();it++){

--- a/src/get_tuple.cpp
+++ b/src/get_tuple.cpp
@@ -22,11 +22,11 @@ string get_string(CharacterVector::iterator begin,CharacterVector::iterator end)
   return s;
 }
 
-void get_tuple_void(CharacterVector& x,unsigned int step,RCPP_UNORDERED_MAP< string, unsigned int >& m) {
+void get_tuple_void(CharacterVector& x,unsigned int step,std::unordered_map< string, unsigned int >& m) {
   
   for(CharacterVector::iterator it = x.begin();it+step-1 != x.end();it++){
     string r = get_string(it,it+step);
-    RCPP_UNORDERED_MAP< string, unsigned int >::iterator m_it = m.find(r);
+    std::unordered_map< string, unsigned int >::iterator m_it = m.find(r);
     if(m_it==m.end()){
       m[r]=1;
     }else{
@@ -38,7 +38,7 @@ void get_tuple_void(CharacterVector& x,unsigned int step,RCPP_UNORDERED_MAP< str
 
 // [[Rcpp::export]]
 List get_tuple_list(ListOf<CharacterVector> x,R_xlen_t step) {
-  RCPP_UNORDERED_MAP< string, unsigned int > res;
+  std::unordered_map< string, unsigned int > res;
   for(ListOf<CharacterVector>::iterator it = x.begin();it != x.end();it++){
     for(R_xlen_t cnt=2;cnt<=step;cnt++){
       CharacterVector tmp = as<CharacterVector>(*it);
@@ -51,7 +51,7 @@ List get_tuple_list(ListOf<CharacterVector> x,R_xlen_t step) {
 
 // [[Rcpp::export]]
 List get_tuple_vector(CharacterVector& x,R_xlen_t step) {
-  RCPP_UNORDERED_MAP< string, unsigned int > res;
+  std::unordered_map< string, unsigned int > res;
   for(R_xlen_t cnt=2;cnt<=step;cnt++){
     get_tuple_void(x,cnt,res);
   }

--- a/src/word_freq.cpp
+++ b/src/word_freq.cpp
@@ -15,11 +15,11 @@ using namespace std;
 
 // [[Rcpp::export]]
 IntegerVector words_freq(const CharacterVector& x) {
-  RCPP_UNORDERED_MAP< string, unsigned int > m;
+  std::unordered_map< string, unsigned int > m;
   CharacterVector::const_iterator it = x.begin();
   for(;it != x.end();it++){
     string r = as<string>(*it);
-    RCPP_UNORDERED_MAP< string, unsigned int >::iterator m_it = m.find(r);
+    std::unordered_map< string, unsigned int >::iterator m_it = m.find(r);
     if(m_it==m.end()){
       m[r]=1;
     }else{


### PR DESCRIPTION
Dear jiebaR maintainer,

As part of the effort to clean up old code and set C++11 as the baseline standard for Rcpp (see https://github.com/RcppCore/Rcpp/issues/1365), we identified that this package is using `RPP_UNORDERED_MAP`, and we would like to suggest substituting this define with the proper `std::unordered_map` type. In this way, we would be able to remove this unnecessary define without breaking your package on CRAN.

We would appreciate if you could merge this PR and send an update to CRAN at your earliest convenience.

Thanks,
On behalf of the Rcpp Core Team